### PR TITLE
Update exportTask.lua

### DIFF
--- a/milo/plugins/exportTask.lua
+++ b/milo/plugins/exportTask.lua
@@ -69,8 +69,8 @@ function ExportTask:cycle(context)
 					for key in pairs(entry.filter) do
 						local items = Milo:getMatches(itemDB:splitKey(key), entry)
 						for _,item in pairs(items) do
-							if context.storage:export(node, nil, item.count, item) == 0 then
-								-- TODO: really shouldn't break here as there may be room in other slots
+							if node.adapter.size() ~= Util.size(node.adapter.list()) and context.storage:export(node, nil, item.count, item) == 0 then
+								-- TODO: really shouldn't break here as there may be room in other slots (probably not)
 								-- leaving for now for performance reasons
 								break
 							end


### PR DESCRIPTION
Cheap fix to stop cascading storage updates from eating up all the working time available after failing exports, this needs to be fleshed out better, if the chest is full, scan the slots for any that match and are not full, stop blindly exporting